### PR TITLE
feat(Makefile): add clean target to scrub untracked sub-chart artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endef
 
 .PRECIOUS: build
 .PHONY: build
-build:
+build: clean
 ifndef CHART
 	$(call all-charts,build)
 else
@@ -48,3 +48,12 @@ endif
 .PHONY: index
 index:
 	@helm repo index $(SERVE_DIR)
+
+# remove untracked sub-chart artifacts before rebuilding
+.PHONY: clean
+clean:
+ifndef CHART
+	$(call all-charts,clean)
+else
+	@rm -rf $(CHARTS_DIR)/$(CHART)/charts
+endif


### PR DESCRIPTION
This proposes to add a `clean` target to the Makefile that is always invoked prior to `build` such that any lingering, untracked sub-chart artifacts are scrubbed before a new build.  

Ref https://github.com/Azure/brigade-charts/pull/25 for the issue inspiring this fix/feature.