### PR TITLE
Make kashti ingress.annotations a "table"

### DIFF
--- a/charts/kashti/values.yaml
+++ b/charts/kashti/values.yaml
@@ -19,7 +19,7 @@ ingress:
   # Used to create Ingress record (should used with service.type: ClusterIP).
   hosts:
     - chart-example.local
-  annotations:
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:


### PR DESCRIPTION
I get warnings in helm when setting it that I'm overwriting a <nil> value with a table:

```
Warning: Merging destination map for chart 'kashti'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
```