### PR TITLE
Add access to pods to generic gateway role

### DIFF
--- a/charts/brigade/templates/gateway-generic-role.yaml
+++ b/charts/brigade/templates/gateway-generic-role.yaml
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets", "pods"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: RoleBinding


### PR DESCRIPTION
This PR grants the generic gateway component access to `pods` in the configured namespace. This is a workaround for https://github.com/Azure/brigade/issues/564.

The change results in the following Kubernetes Role:

```yaml
# Source: brigade/templates/gateway-generic-role.yaml
---
kind: Role
apiVersion: rbac.authorization.k8s.io/v1beta1
metadata:
  name: release-name-brigade-generic-gateway
  labels:
    app.kubernetes.io/name: release-name-brigade
    helm.sh/chart: "brigade-0.21.0"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/managed-by: "Tiller"
rules:
- apiGroups: [""]
  resources: ["secrets", "pods"]
  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
```

Now, if the component doesn't have access to pods, it continues to work properly - however, the logs are completely unusable, with the following error everywhere:

```
E0222 01:35:31.658531       1 reflector.go:205] github.com/Azure/brigade/pkg/storage/kube/apicache/liststore.go:36: Failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:brigade:brigade-brigade-generic-gateway" cannot list resource "pods" in API group "" in the namespace "brigade"
```

I tested that builds are created, but the logs are unusable - if we think we don't actually need the logs, we can simply close this PR.

cc @vdice, @dgkanatsios 